### PR TITLE
Adjust traits to be static

### DIFF
--- a/src/algorithms/trial_division.rs
+++ b/src/algorithms/trial_division.rs
@@ -1,9 +1,9 @@
-use crate::Factorize;
+use crate::PrimeFactorization;
 
 pub struct TrialDivision;
 
-impl Factorize for TrialDivision {
-    fn factorize(&self, n: u128) -> Vec<u128> {
+impl PrimeFactorization for TrialDivision {
+    fn prime_factorization(n: u128) -> Vec<u128> {
         if n <= 1 {
             return vec![n];
         }
@@ -62,11 +62,11 @@ mod tests {
 
     #[test]
     fn factorize_prime() {
-        assert_eq!(TrialDivision.factorize(13), vec![13]);
+        assert_eq!(TrialDivision::prime_factorization(13), vec![13]);
     }
 
     #[test]
     fn factorize_composite() {
-        assert_eq!(TrialDivision.factorize(12), vec![2, 2, 3]);
+        assert_eq!(TrialDivision::prime_factorization(12), vec![2, 2, 3]);
     }
 }

--- a/src/factorization.rs
+++ b/src/factorization.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::Factorize;
+use crate::PrimeFactorization;
 
 static SUPERSCRIPTS: [&str; 10] = ["⁰", "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"];
 
@@ -11,10 +11,10 @@ pub struct Factorization {
 }
 
 impl Factorization {
-    pub fn new(n: u128, f: impl Factorize) -> Self {
+    pub fn new<F: PrimeFactorization>(n: u128) -> Self {
         Factorization {
             number: n,
-            factors: f.factorize(n),
+            factors: F::prime_factorization(n),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ pub mod traits;
 pub mod primality_test;
 
 pub use factorization::Factorization;
-pub use traits::Factorize;
+pub use traits::PrimeFactorization;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ fn main() {
         .parse()
         .expect("Please provide a valid positive integer");
     match method.as_str() {
-        "pollards_rho" => println!("{}", Factorization::new(n, algorithms::PollardsRho)),
-        "trial_division" => println!("{}", Factorization::new(n, algorithms::TrialDivision)),
+        "pollards_rho" => println!("{}", Factorization::new::<algorithms::PollardsRho>(n)),
+        "trial_division" => println!("{}", Factorization::new::<algorithms::TrialDivision>(n)),
         _ => eprintln!("Unknown algorithm. Available options: pollards_rho, trial_division"),
     }
 }

--- a/src/primality_test/miller_rabin.rs
+++ b/src/primality_test/miller_rabin.rs
@@ -1,13 +1,13 @@
 mod composite_evidence;
 mod utils;
 
-use crate::traits::PrimalityTest;
 use self::composite_evidence::CompositeEvidence;
+use crate::traits::PrimalityTest;
 
 pub struct MillerRabin;
 
 impl PrimalityTest for MillerRabin {
-    fn is_prime(&self, p: u128) -> bool {
+    fn is_prime(p: u128) -> bool {
         if p == 2 || p == 3 {
             return true;
         }
@@ -21,7 +21,7 @@ impl PrimalityTest for MillerRabin {
 fn miller_rabin(p: u128, trials: usize) -> bool {
     let evidence = CompositeEvidence::new(p);
     let likely_prime = |witness| !evidence.witnessed_by(witness);
-    utils::RandomIntegers::new(2..p-1)
+    utils::RandomIntegers::new(2..p - 1)
         .take(trials)
         .all(likely_prime)
 }
@@ -43,7 +43,7 @@ mod tests {
             2u128.pow(61) - 1,
         ];
         for prime in primes {
-            assert!(MillerRabin.is_prime(prime), "Failed on prime {prime}");
+            assert!(MillerRabin::is_prime(prime), "Failed on prime {prime}");
         }
     }
 
@@ -51,7 +51,7 @@ mod tests {
     fn test_composite_numbers() {
         for composite in [4, 15, 35, 49, 1001] {
             assert!(
-                !MillerRabin.is_prime(composite),
+                !MillerRabin::is_prime(composite),
                 "Failed on composite {composite}"
             );
         }
@@ -66,7 +66,7 @@ mod tests {
         ];
         for carmichael in carmichaels {
             assert!(
-                !MillerRabin.is_prime(carmichael),
+                !MillerRabin::is_prime(carmichael),
                 "Failed on Carmichael number {carmichael}"
             );
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
-pub trait Factorize {
-    fn factorize(&self, n: u128) -> Vec<u128>;
+pub trait PrimeFactorization {
+    fn prime_factorization(n: u128) -> Vec<u128>;
 }
 
 pub trait PrimalityTest {
-    fn is_prime(&self, p: u128) -> bool;
+    fn is_prime(p: u128) -> bool;
 }


### PR DESCRIPTION
## Changes
- Change trait name from `Factorize` to `PrimeFactorization`
- Traits methods are now static for `PrimalityTest::is_prime` and `PrimeFactorization::prime_factorization`
