### PR TITLE
Change from BigUInt to BigInt

### DIFF
--- a/src/algorithms/trial_division.rs
+++ b/src/algorithms/trial_division.rs
@@ -1,5 +1,5 @@
 use crate::PrimeFactorization;
-use num_bigint::BigUint;
+use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::One;
 
@@ -10,14 +10,14 @@ impl PrimeFactorization for TrialDivision {
         if n <= 1 {
             return vec![n];
         }
-        trial_div(BigUint::from(n))
+        trial_div(BigInt::from(n))
             .into_iter()
             .map(|d| d.try_into().unwrap())
             .collect()
     }
 }
 
-fn trial_div(mut n: BigUint) -> Vec<BigUint> {
+fn trial_div(mut n: BigInt) -> Vec<BigInt> {
     let mut factors = vec![];
     let mut divisors = DivisorCandidates::new();
     while let Some(d) = divisors.next() {
@@ -35,28 +35,28 @@ fn trial_div(mut n: BigUint) -> Vec<BigUint> {
     factors
 }
 
-fn is_still_undivided(n: &BigUint) -> bool {
+fn is_still_undivided(n: &BigInt) -> bool {
     !n.is_one()
 }
 
 struct DivisorCandidates {
-    current: BigUint,
+    current: BigInt,
 }
 
 impl DivisorCandidates {
     fn new() -> Self {
         DivisorCandidates {
-            current: BigUint::from(2u8),
+            current: BigInt::from(2u8),
         }
     }
 }
 
 impl Iterator for DivisorCandidates {
-    type Item = BigUint;
+    type Item = BigInt;
 
     fn next(&mut self) -> Option<Self::Item> {
         let output = self.current.clone();
-        self.current = if self.current == BigUint::from(2u8) {
+        self.current = if self.current == BigInt::from(2u8) {
             &self.current + 1u8
         } else {
             &self.current + 2u8

--- a/src/primality_test/miller_rabin.rs
+++ b/src/primality_test/miller_rabin.rs
@@ -3,7 +3,7 @@ mod utils;
 
 use self::composite_evidence::CompositeEvidence;
 use crate::traits::PrimalityTest;
-use num_bigint::BigUint;
+use num_bigint::BigInt;
 
 pub struct MillerRabin;
 
@@ -15,14 +15,14 @@ impl PrimalityTest for MillerRabin {
         if p < 2 || p % 2 == 0 {
             return false;
         }
-        miller_rabin(&BigUint::from(p), 10)
+        miller_rabin(&BigInt::from(p), 10)
     }
 }
 
-fn miller_rabin(p: &BigUint, trials: usize) -> bool {
+fn miller_rabin(p: &BigInt, trials: usize) -> bool {
     let evidence = CompositeEvidence::new(p);
     let likely_prime = |witness| !evidence.witnessed_by(&witness);
-    utils::RandomIntegers::new(BigUint::from(2u8)..p - 1u8)
+    utils::RandomIntegers::new(BigInt::from(2u8)..p - 1u8)
         .take(trials)
         .all(likely_prime)
 }

--- a/src/primality_test/miller_rabin/composite_evidence.rs
+++ b/src/primality_test/miller_rabin/composite_evidence.rs
@@ -1,40 +1,40 @@
 use super::utils;
-use num_bigint::BigUint;
+use num_bigint::BigInt;
 use num_traits::One;
 
 pub struct CompositeEvidence<'a> {
-    n: &'a BigUint,
+    n: &'a BigInt,
     n_minus_1: Decomposed,
 }
 
 impl<'a> CompositeEvidence<'a> {
-    pub fn new(n: &'a BigUint) -> Self {
+    pub fn new(n: &'a BigInt) -> Self {
         let n_minus_1 = Decomposed::new(n - 1u8);
         Self { n, n_minus_1 }
     }
 
-    pub fn witnessed_by(&self, witness: &BigUint) -> bool {
+    pub fn witnessed_by(&self, witness: &BigInt) -> bool {
         match self.raise_to_n_minus_1_mod_n(witness) {
             Ok(result) => fails_fermats_condition(result),
             Err(FoundNonTrivialSqrtOf1) => true,
         }
     }
 
-    fn raise_to_n_minus_1_mod_n(&self, base: &BigUint) -> ExponentiationResult {
+    fn raise_to_n_minus_1_mod_n(&self, base: &BigInt) -> ExponentiationResult {
         let odd_factor_in_exp = &self.n_minus_1.odd_factor;
         let mut result = base.modpow(odd_factor_in_exp, &self.n);
         for _ in 0..self.n_minus_1.exponent_of_2 {
             if self.is_nontrivial_sqrt_of_1(&result) {
                 return Err(FoundNonTrivialSqrtOf1);
             }
-            result = result.modpow(&BigUint::from(2u8), &self.n);
+            result = result.modpow(&BigInt::from(2u8), &self.n);
         }
         Ok(RaisedToNMinus1ModN(result))
     }
 
-    pub fn is_nontrivial_sqrt_of_1(&self, solution: &BigUint) -> bool {
-        let squared = solution.modpow(&BigUint::from(2u8), &self.n);
-        squared == BigUint::one() && solution != &BigUint::one() && solution != &(self.n - 1u8)
+    pub fn is_nontrivial_sqrt_of_1(&self, solution: &BigInt) -> bool {
+        let squared = solution.modpow(&BigInt::from(2u8), &self.n);
+        squared == BigInt::one() && solution != &BigInt::one() && solution != &(self.n - 1u8)
     }
 }
 
@@ -44,21 +44,21 @@ fn fails_fermats_condition(r: RaisedToNMinus1ModN) -> bool {
 
 type ExponentiationResult = Result<RaisedToNMinus1ModN, FoundNonTrivialSqrtOf1>;
 
-struct RaisedToNMinus1ModN(BigUint);
+struct RaisedToNMinus1ModN(BigInt);
 
 struct FoundNonTrivialSqrtOf1;
 
 struct Decomposed {
     exponent_of_2: u32,
-    odd_factor: BigUint,
+    odd_factor: BigInt,
 }
 
 impl Decomposed {
     /// Decomposes `number` into `exponent_of_2` and `odd_factor`,
     /// where `number = 2^exponent_of_2 * odd_factor`.
-    pub fn new(number: BigUint) -> Self {
+    pub fn new(number: BigInt) -> Self {
         let exponent_of_2 = utils::highest_power_of_2_divisor(&number);
-        let odd_factor = number / BigUint::from(2u8).pow(exponent_of_2);
+        let odd_factor = number / BigInt::from(2u8).pow(exponent_of_2);
         Self {
             exponent_of_2,
             odd_factor,

--- a/src/primality_test/miller_rabin/utils.rs
+++ b/src/primality_test/miller_rabin/utils.rs
@@ -1,14 +1,14 @@
-use num_bigint::{BigUint, RandBigInt};
+use num_bigint::{BigInt, RandBigInt};
 use num_integer::Integer;
 use std::ops::Range;
 
 pub struct RandomIntegers {
-    lo: BigUint,
-    hi: BigUint,
+    lo: BigInt,
+    hi: BigInt,
 }
 
 impl RandomIntegers {
-    pub fn new(range: Range<BigUint>) -> Self {
+    pub fn new(range: Range<BigInt>) -> Self {
         Self {
             lo: range.start,
             hi: range.end,
@@ -17,14 +17,14 @@ impl RandomIntegers {
 }
 
 impl Iterator for RandomIntegers {
-    type Item = BigUint;
+    type Item = BigInt;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(rand::thread_rng().gen_biguint_range(&self.lo, &self.hi))
+        Some(rand::thread_rng().gen_bigint_range(&self.lo, &self.hi))
     }
 }
 
-pub fn highest_power_of_2_divisor(base: &BigUint) -> u32 {
+pub fn highest_power_of_2_divisor(base: &BigInt) -> u32 {
     let mut exp = 0;
     let mut base = base.clone();
     while base.is_even() {


### PR DESCRIPTION
## Changes
Prefer the type `BigInt` to `BigUint` because of support for many more operators. Although we lose the type safety of ensuring usage of non-negative numbers, we are willing to sacrifice that to get some more flexibility.

- Switch from `BigUint` to `BigInt` throught the repository.