### PR TITLE
Fix needless borrow and copy on clone

### DIFF
--- a/src/algorithms/fermats_factorization_method.rs
+++ b/src/algorithms/fermats_factorization_method.rs
@@ -9,18 +9,18 @@ pub struct FermatsFactorizationMethod;
 
 impl Factorize for FermatsFactorizationMethod {
     fn factorize(n: &U512) -> U512 {
-        let mut a = init(&n);
+        let mut a = init(n);
         let mut b2 = a * a - n;
         while !is_perfect_square(&b2) {
             a += U512::ONE;
-            b2 = &a * &a - n;
+            b2 = a * a - n;
         }
         a + b2.sqrt()
     }
 }
 
 fn init(n: &U512) -> U512 {
-    if is_perfect_square(&n) {
+    if is_perfect_square(n) {
         n.sqrt()
     } else {
         n.sqrt() + U512::ONE
@@ -29,7 +29,7 @@ fn init(n: &U512) -> U512 {
 
 fn is_perfect_square(n: &U512) -> bool {
     let sqrt = n.sqrt();
-    &sqrt * &sqrt == *n
+    sqrt * sqrt == *n
 }
 
 impl PrimeFactorization for FermatsFactorizationMethod {

--- a/src/algorithms/pollards_rho.rs
+++ b/src/algorithms/pollards_rho.rs
@@ -12,10 +12,10 @@ pub struct PollardsRho;
 impl Factorize for PollardsRho {
     fn factorize(n: &U512) -> U512 {
         let init = U512::from(2u8);
-        let pseudorandom_fn = utils::generate_pseudorandom_fn(&n);
-        let finished = move |x: &U512, y: &U512| x.abs_diff(*y).gcd(&n) != U512::from(1u8);
+        let pseudorandom_fn = utils::generate_pseudorandom_fn(n);
+        let finished = move |x: &U512, y: &U512| x.abs_diff(*y).gcd(n) != U512::from(1u8);
         let (tortoise, hare) = utils::floyds_cycle_detection(init, &pseudorandom_fn, &finished);
-        hare.abs_diff(tortoise).gcd(&n)
+        hare.abs_diff(tortoise).gcd(n)
     }
 }
 

--- a/src/algorithms/trial_division.rs
+++ b/src/algorithms/trial_division.rs
@@ -8,22 +8,22 @@ pub struct TrialDivision;
 impl PrimeFactorization for TrialDivision {
     fn prime_factorization(n: &U512) -> Vec<U512> {
         if n <= &U512::one() {
-            return vec![n.clone()];
+            return vec![*n];
         }
-        trial_div(n.clone())
+        trial_div(*n)
     }
 }
 
 fn trial_div(mut n: U512) -> Vec<U512> {
     let mut factors = vec![];
-    let mut divisors = DivisorCandidates::new();
-    while let Some(d) = divisors.next() {
+    let divisors = DivisorCandidates::new();
+    for d in divisors {
         if n < d.pow(2) {
             break;
         }
         while n.is_multiple_of(&d) {
             n /= &d;
-            factors.push(d.clone());
+            factors.push(d);
         }
     }
     if is_still_undivided(&n) {
@@ -52,11 +52,11 @@ impl Iterator for DivisorCandidates {
     type Item = U512;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let output = self.current.clone();
+        let output = self.current;
         self.current = if self.current == U512::from(2u8) {
-            &self.current + U512::from(1u8)
+            self.current + U512::from(1u8)
         } else {
-            &self.current + U512::from(2u8)
+            self.current + U512::from(2u8)
         };
         Some(output)
     }

--- a/src/orchestration/recursive.rs
+++ b/src/orchestration/recursive.rs
@@ -21,7 +21,7 @@ where
 {
     fn prime_factorization(n: &U512) -> Vec<U512> {
         let max_successive_failures = 100;
-        Self::new(max_successive_failures).recursive_factorization(n.clone())
+        Self::new(max_successive_failures).recursive_factorization(*n)
     }
 }
 
@@ -42,7 +42,7 @@ where
         let mut factors = vec![];
         let two = U512::from(2u8);
         while n.is_even() {
-            factors.push(two.clone());
+            factors.push(two);
             n /= &two;
         }
         self.recursion_step(n, &mut factors, 0);
@@ -62,11 +62,11 @@ where
         match self.classify_factor(Factorizer::factorize(&n), &n) {
             DivisorOfN::Trivial(_) => self.recursion_step(n, factors, retried + 1),
             DivisorOfN::Prime(p) => {
-                factors.push(p.clone());
+                factors.push(p);
                 self.recursion_step(n / p, factors, 0);
             }
             DivisorOfN::Composite(d) => {
-                self.recursion_step(n / d.clone(), factors, 0);
+                self.recursion_step(n / d, factors, 0);
                 self.recursion_step(d, factors, 0);
             }
         }

--- a/src/primality_test/miller_rabin.rs
+++ b/src/primality_test/miller_rabin.rs
@@ -17,7 +17,7 @@ impl PrimalityTest for MillerRabin {
         if p < &two || p.is_multiple_of(&two) {
             return false;
         }
-        miller_rabin(&p, 10)
+        miller_rabin(p, 10)
     }
 }
 

--- a/src/primality_test/miller_rabin/composite_evidence.rs
+++ b/src/primality_test/miller_rabin/composite_evidence.rs
@@ -23,18 +23,18 @@ impl<'a> CompositeEvidence<'a> {
 
     fn raise_to_n_minus_1_mod_n(&self, base: &U512) -> ExponentiationResult {
         let odd_factor_in_exp = &self.n_minus_1.odd_factor;
-        let mut result = modpow(base, odd_factor_in_exp, &self.n);
+        let mut result = modpow(base, odd_factor_in_exp, self.n);
         for _ in 0..self.n_minus_1.exponent_of_2 {
             if self.is_nontrivial_sqrt_of_1(&result) {
                 return Err(FoundNonTrivialSqrtOf1);
             }
-            result = modpow(&result, &U512::from(2u8), &self.n);
+            result = modpow(&result, &U512::from(2u8), self.n);
         }
         Ok(RaisedToNMinus1ModN(result))
     }
 
     pub fn is_nontrivial_sqrt_of_1(&self, solution: &U512) -> bool {
-        let squared = modpow(solution, &U512::from(2u8), &self.n);
+        let squared = modpow(solution, &U512::from(2u8), self.n);
         squared == U512::one()
             && solution != &U512::one()
             && solution != &(self.n - U512::from(1u8))
@@ -44,7 +44,7 @@ impl<'a> CompositeEvidence<'a> {
 fn modpow(base: &U512, exponent: &U512, modulus: &U512) -> U512 {
     let mut result = U512::from(1u8);
     let mut base = base % modulus;
-    let mut exp = exponent.clone();
+    let mut exp = *exponent;
     while exp > U512::from(0u8) {
         if exp.is_odd() {
             result = result * base % modulus;

--- a/src/primality_test/miller_rabin/utils.rs
+++ b/src/primality_test/miller_rabin/utils.rs
@@ -23,7 +23,7 @@ impl Iterator for RandomIntegers {
 
 pub fn highest_power_of_2_divisor(base: &U512) -> u32 {
     let mut exp = 0;
-    let mut base = base.clone();
+    let mut base = *base;
     while base.is_even() {
         exp += 1;
         base /= U512::from(2u8);


### PR DESCRIPTION
## Changes
`bnum` types implement copy which means that we can remove some of the previous clones we had when we used `num-bigint`, see #6, #8, #9. Since we also adjusted the traits in #11 we had some needless borrows downstream.

### Relevant PRs
- #6
- #8
- #9
- #11