### PR TITLE
Create CliErr enum that is matched in main

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,14 +6,11 @@ type CommandTraitObj = Box<dyn Command>;
 pub struct CommandMap(BTreeMap<String, CommandTraitObj>);
 
 impl CommandMap {
-    pub fn get(&self, name: &str) -> Result<&CommandTraitObj, String> {
-        self.0.get(name).ok_or(format!(
-            "Unknown algorithm. Available options: {}",
-            self.available_methods()
-        ))
+    pub fn get(&self, name: &str) -> Option<&CommandTraitObj> {
+        self.0.get(name)
     }
 
-    pub fn available_methods(&self) -> String {
+    pub fn available_commands(&self) -> String {
         self.0
             .keys()
             .map(|s| s.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,28 +3,48 @@ use rustic_factors::commands::CommandMap;
 use std::env;
 
 fn main() {
-    match run(env::args().collect()) {
+    let args: Vec<String> = env::args().collect();
+    match cli(&args) {
         Ok(result) => println!("{result}"),
-        Err(msg) => eprintln!("{msg}"),
+        Err(CliErr::ParseIntErr) => eprintln!("Please provide a number in range [0, 2⁵¹²)"),
+        Err(CliErr::IncorrectNumArgs) => eprintln!("Usage: {} <algorithm> <number>", args[0]),
+        Err(CliErr::CommandNotFound(commands)) => {
+            eprintln!("Unknown command. Available options: {commands}.")
+        }
     }
 }
 
-fn run(args: Vec<String>) -> Result<String, String> {
-    if args.len() < 3 {
-        return Err(format!("Usage: {} <algorithm> <number>", args[0]));
+fn cli(args: &[String]) -> Result<String, CliErr> {
+    if args.len() != 3 {
+        return Err(CliErr::IncorrectNumArgs);
     }
-    let (n, method) = parse(args)?;
+    let input = parse(args)?;
     let cmd_map = CommandMap::default();
-    let cmd = cmd_map.get(&method)?;
-    Ok(cmd.run(&n))
+    match cmd_map.get(&input.command_name) {
+        Some(cmd) => Ok(cmd.run(&input.number)),
+        None => Err(CliErr::CommandNotFound(cmd_map.available_commands())),
+    }
 }
 
-fn parse(args: Vec<String>) -> Result<(U512, String), String> {
+fn parse(args: &[String]) -> Result<ParsedInput, CliErr> {
     let method = String::from(&args[1]);
-    let n: U512 = args[2]
-        .parse()
-        .map_err(|_| String::from("Please provide a valid positive integer <= 2⁵¹²"))?;
-    Ok((n, method))
+    let n: U512 = args[2].parse().map_err(|_| CliErr::ParseIntErr)?;
+    Ok(ParsedInput {
+        number: n,
+        command_name: method,
+    })
+}
+
+struct ParsedInput {
+    number: U512,
+    command_name: String,
+}
+
+#[derive(PartialEq, Debug)]
+enum CliErr {
+    CommandNotFound(String),
+    ParseIntErr,
+    IncorrectNumArgs,
 }
 
 #[cfg(test)]
@@ -34,8 +54,8 @@ mod tests {
     #[test]
     fn happy_cases() {
         let cmap = CommandMap::default();
-        for method in cmap.available_methods().split(", ") {
-            assert!(run(vec![
+        for method in cmap.available_commands().split(", ") {
+            assert!(cli(&[
                 String::from("rustic_factors"),
                 String::from(method),
                 String::from("123")
@@ -46,19 +66,21 @@ mod tests {
 
     #[test]
     fn unsupported_method() {
-        assert!(run(vec![
+        match cli(&[
             String::from("rustic_factors"),
             String::from("unsupported method"),
-            String::from("123")
-        ])
-        .is_err());
+            String::from("123"),
+        ]) {
+            Err(CliErr::CommandNotFound(_)) => (),
+            _ => panic!(),
+        }
     }
 
     #[test]
     fn too_few_args() {
         assert_eq!(
-            run(vec![String::from("rustic_factors")]).unwrap_err(),
-            String::from("Usage: rustic_factors <algorithm> <number>")
+            cli(&[String::from("rustic_factors")]).unwrap_err(),
+            CliErr::IncorrectNumArgs,
         );
     }
 }


### PR DESCRIPTION
## Changes
- Creates a new enum CliErr that better communicates the types of CLI errors we get in main.
- Changed CommandMap from Result type to Option type.
- Changed CommandMap's method from "available_methods" to "available_commands"